### PR TITLE
Support substring and replacement #8

### DIFF
--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -12,8 +12,8 @@ Also support some minimal Bash extensions to expansion [3]:
 
 (Pull requests to remove limitations are welcome.)
 
-- Only simple nested expansions are supported such as in `${foo:-$bar}` or
-`${foo:-${bar}}` but not complex expansions such as in `${foo:-${bar:-$baz}}`
+- Only simple nested expansions of the forms $variable and ${variable} are
+supported and not complex expansions such as in `${foo:-${bar:-$baz}}`
 - Only ASCII alphanumeric characters and underscores are supported in parameter
 names. (Per POSIX, parameter names may not begin with a numeral.)
 - Assignment expansions do not mutate the real environment.
@@ -69,9 +69,11 @@ def follow_sigil(shl, env):
 
 
 def expand_simple(s, env):
-    """Expand the string for simple plain variable as in $param or ${param}
-    replacement (without any extra nested expansion).
+    """Expand a string containing shell variable substitutions.
+    This expands the forms $variable and ${variable} only.
+    Non-existent variables are left unchanged.
     Uses the provided environment dict.
+    Similar to ``os.path.expandvars``.
     """
     for name, value in env.items():
         s = s.replace(f"${name}", value)

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -151,6 +151,32 @@ def follow_brace(shl, env):
                 return subst
             else:
                 raise ParameterExpansionParseError()
+        elif modifier == "/":
+            # this is a string replacement
+            arg1 = next(shl)
+            replace_all = False
+            if arg1 == "/":
+                # with // replace all occurences
+                replace_all = True
+                arg1 = next(shl)
+
+            sep = next(shl)
+            if sep != "/":
+                raise ParameterExpansionParseError("Illegal replacement syntax")
+
+            # the repl of a replacement may be empty
+            try:
+                arg2 = next(shl)
+            except StopIteration:
+                arg2 = ""
+
+            if param_set_and_not_null:
+                if replace_all:
+                    return subst.replace(arg1, arg2)
+                else:
+                    return subst.replace(arg1, arg2, 1)
+
+            return subst
         else:
             if modifier == "-":
                 word = next(shl)

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -181,7 +181,9 @@ def follow_brace(shl, env):
                 replace_all = True
                 arg1 = next(shl)
 
-            sep = next(shl)
+            # the repl of a replacement may not exist at all with no trailing
+            # slash or it may be empty
+            sep = next(shl, "/")
             if sep != "/":
                 raise ParameterExpansionParseError("Illegal replacement syntax")
 

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -19,9 +19,9 @@ completely reimplementing [POSIX pattern matching][2]
 [2]: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13
 """
 
+import os
 from fnmatch import fnmatchcase
 from itertools import takewhile
-from os import getenv
 from shlex import shlex
 
 

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -30,6 +30,7 @@ def expand(s, env=None):
     Uses the provided environment dict or the actual environment."""
     if env is None:
         env = dict(os.environ)
+    s = expand_simple(s, env)
     return "".join(expand_tokens(s, env))
 
 
@@ -58,6 +59,15 @@ def follow_sigil(shl, env):
         consume = iter(list(takewhile(lambda t: t != "}", shl)))
         return follow_brace(consume, env)
     return env.get(param, "")
+
+
+def expand_simple(s, env):
+    """Expand the string for simple $-prefixed variable (no curly braces).
+    Uses the provided environment dict.
+    """
+    for name, value in env.items():
+        s = s.replace(f"${name}", value)
+    return s
 
 
 def remove_affix(subst, shl, suffix=True):

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -111,7 +111,6 @@ def follow_brace(shl, env):
         return str(len(subst))
     subst = env.get(param, "")
     param_set_and_not_null = bool(subst and (param in env))
-    param_set_but_null = bool((param in env) and not subst)
     param_unset = param not in env
     try:
         modifier = next(shl)

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -115,6 +115,18 @@ replace_test_cases = {
     ),
 }
 
+simple_test_cases = {
+    # string,               env, result
+    "-${parameter/$aa/$bb}-": (
+        dict(parameter="FOO/bb/cc", aa="FOO", bb="BAR",),
+        "-BAR/bb/cc-",
+    ),
+    "-$parameter/$aa/$bb-": (
+        dict(parameter="aa/bb/cc", aa="FOO", bb="BAR",),
+        "-aa/bb/cc/FOO/BAR-",
+    ),
+}
+
 test_envs = (
     {
         "parameter": "set",
@@ -161,3 +173,8 @@ def test_replace():
     for string, (parameter, expected) in replace_test_cases.items():
         env = {"parameter": parameter}
         assert pe.expand(string, env) == expected, (string, parameter)
+
+
+def test_simple():
+    for string, (env, expected) in simple_test_cases.items():
+        assert pe.expand(string, env) == expected, (string, env)

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -95,6 +95,26 @@ substring_test_cases = {
     ),
 }
 
+replace_test_cases = {
+    # string,               parameter, result
+    "-${parameter/aa/bb}-": (
+        "aa/bb/cc",
+        "-bb/bb/cc-",
+    ),
+    "-${parameter/aa/}-": (
+        "aa/bb/cc",
+        "-/bb/cc-",
+    ),
+    "-${parameter/aa/zz}-": (
+        "aa/bb/aa",
+        "-zz/bb/aa-",
+    ),
+    "-${parameter//aa/zz}-": (
+        "aa/bb/aa",
+        "-zz/bb/zz-",
+    ),
+}
+
 test_envs = (
     {
         "parameter": "set",
@@ -126,16 +146,18 @@ def test():
             except pe.ParameterExpansionNullError:
                 assert tc[i] == "error", (string, tc[i], test_case_map[i])
 
-    for string, tc in affix_test_cases.items():
-        env = {
-            "parameter": tc[0],
-        }
-        result = string, pe.expand(string, env), tc
-        assert result[1] == tc[1], result
+    for string, (parameter, expected) in affix_test_cases.items():
+        env = {"parameter": parameter}
+        assert pe.expand(string, env) == expected
 
-    for string, tc in substring_test_cases.items():
-        env = {
-            "parameter": tc[0],
-        }
-        result = string, pe.expand(string, env), tc
-        assert result[1] == tc[1], result
+
+def test_substring():
+    for string, (parameter, expected) in substring_test_cases.items():
+        env = {"parameter": parameter}
+        assert pe.expand(string, env) == expected, (string, parameter)
+
+
+def test_replace():
+    for string, (parameter, expected) in replace_test_cases.items():
+        env = {"parameter": parameter}
+        assert pe.expand(string, env) == expected, (string, parameter)

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -118,11 +118,19 @@ replace_test_cases = {
 simple_test_cases = {
     # string,               env, result
     "-${parameter/$aa/$bb}-": (
-        dict(parameter="FOO/bb/cc", aa="FOO", bb="BAR",),
+        dict(
+            parameter="FOO/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
         "-BAR/bb/cc-",
     ),
     "-$parameter/$aa/$bb-": (
-        dict(parameter="aa/bb/cc", aa="FOO", bb="BAR",),
+        dict(
+            parameter="aa/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
         "-aa/bb/cc/FOO/BAR-",
     ),
 }

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -79,6 +79,22 @@ affix_test_cases = {
     ),
 }
 
+substring_test_cases = {
+    # string,               parameter, result
+    "-${parameter:0:2}-": (
+        "aa/bb/cc",
+        "-aa-",
+    ),
+    "-${parameter:3:2}-": (
+        "aa/bb/cc",
+        "-bb-",
+    ),
+    "-${parameter:6}-": (
+        "aa/bb/cc",
+        "-cc-",
+    ),
+}
+
 test_envs = (
     {
         "parameter": "set",
@@ -111,6 +127,13 @@ def test():
                 assert tc[i] == "error", (string, tc[i], test_case_map[i])
 
     for string, tc in affix_test_cases.items():
+        env = {
+            "parameter": tc[0],
+        }
+        result = string, pe.expand(string, env), tc
+        assert result[1] == tc[1], result
+
+    for string, tc in substring_test_cases.items():
         env = {
             "parameter": tc[0],
         }

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -113,6 +113,14 @@ replace_test_cases = {
         "aa/bb/aa",
         "-zz/bb/zz-",
     ),
+    "-${parameter/aa}-": (
+        "aa/bb/aa",
+        "-/bb/aa-",
+    ),
+    "-${parameter//aa}-": (
+        "aa/bb/aa",
+        "-/bb/-",
+    ),
 }
 
 simple_test_cases = {


### PR DESCRIPTION
This PR adds minimal support for some Bash idioms for #8

- simple replacement as in ${foo/bar/baz}
- substrings as in  ${foo:4:2}

In addition:
- add support for plain $parameter substitution including
some simple nesting.
- apply some minor code cleanups

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>