### PR TITLE
Keep spaces. Expand nested params. Improve tests. Fix substring.

### DIFF
--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -164,11 +164,13 @@ def expand_simple(s, env):
     Uses the provided environment dict.
     Similar to ``os.path.expandvars``.
     """
-    # TODO: validate if a plain replace is really what is supposed to happen
-    # in particular simple expansion may need to happen on tokens rather than
-    # on the whole string.
-    # For instance, with foo=bar, abc$fooBAR expands to abc
-    for name, value in env.items():
+    env_by_decreasing_name_length = sorted(
+        env.items(),
+        # [0] is the name.  minus its length gets the longest first.
+        key=lambda name_value: -len(name_value[0]),
+    )
+
+    for name, value in env_by_decreasing_name_length:
         s = s.replace(f"${name}", value)
         name = "{" + name + "}"
         s = s.replace(f"${name}", value)

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -35,8 +35,7 @@ import os
 import re
 import sys
 from fnmatch import fnmatchcase
-from itertools import groupby
-from itertools import takewhile
+from itertools import groupby, takewhile
 from shlex import shlex
 
 # Tracing flags: set to True to enable debug trace

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -156,7 +156,10 @@ def follow_sigil(shl, env, strict=False):
         # note: downstream code expects an iterator with a next() and not a list
         inside_sigils = iter(inside_sigils)
         return follow_brace(inside_sigils, env, strict)
-    return env.get(param, "")
+    expanded = env.get(param)
+    if strict and expanded is None:
+        raise ParameterExpansionNullError(param)
+    return expanded or ""
 
 
 def expand_simple(s, env):

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -3,7 +3,10 @@
 """
 Given a string, expand that string using POSIX [parameter expansion][1].
 
-Also support some minimal Bash extensions to expansion [3]:
+Most nested expression expansions should be working now, but YMMV. Things such
+as in `${foo:-${bar:-$baz}}` should work fine.
+
+Also support some level of Bash extensions to expansion [3]:
 - pattern substitution with `${foo/bar/baz}` (but only plain strings and not patterns)
 - substring expansion with `${foo:4:2}
 
@@ -11,9 +14,6 @@ Also support some minimal Bash extensions to expansion [3]:
 ## Limitations
 
 (Pull requests to remove limitations are welcome.)
-
-- Most nested expression expansions should be supported now, but YMMV. Things such
-as in `${foo:-${bar:-$baz}}`
 
 - Only ASCII alphanumeric characters and underscores are supported in parameter
 names. (Per POSIX, parameter names may not begin with a numeral.)

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -150,10 +150,12 @@ def get_plain_expressions(s):
 def follow_sigil(shl, env, strict=False):
     param = next(shl)
     if param == "{":
-        consume = list(takewhile(lambda t: t != "}", shl))
-        logger_debug("follow_sigil: consume:", consume)
-        consume = iter(consume)
-        return follow_brace(consume, env, strict)
+        # note: we consume the iterator here on purpose
+        inside_sigils = list(takewhile(lambda t: t != "}", shl))
+        logger_debug("follow_sigil: inside_sigils:", inside_sigils)
+        # note: downstream code expects an iterator with a next() and not a list
+        inside_sigils = iter(inside_sigils)
+        return follow_brace(inside_sigils, env, strict)
     return env.get(param, "")
 
 

--- a/parameter_expansion/pe.py
+++ b/parameter_expansion/pe.py
@@ -30,8 +30,7 @@ import logging
 import os
 import sys
 from fnmatch import fnmatchcase
-from itertools import groupby
-from itertools import takewhile
+from itertools import groupby, takewhile
 from shlex import shlex
 
 # Tracing flags: set to True to enable debug trace
@@ -44,7 +43,7 @@ if TRACE:
 
 
 def logger_debug(*args):
-    return logger.debug(' '.join(a if isinstance(a, str) else repr(a) for a in args))
+    return logger.debug(" ".join(a if isinstance(a, str) else repr(a) for a in args))
 
 
 def expand(s, env=None, strict=False):
@@ -71,18 +70,17 @@ def expand_tokens(s, env, strict=False):
     while True:
         try:
             before_dollar = "".join(takewhile(lambda t: t != "$", tokens))
-            logger_debug('expand_tokens: before_dollar:', repr(before_dollar))
+            logger_debug("expand_tokens: before_dollar:", repr(before_dollar))
             yield before_dollar
             sigil = follow_sigil(tokens, env, strict)
-            logger_debug('expand_tokens: sigil:', repr(sigil))
+            logger_debug("expand_tokens: sigil:", repr(sigil))
             yield sigil
         except StopIteration:
             return
 
 
 def tokenize(s):
-    """Yield token strings lexed from the shell string s.
-    """
+    """Yield token strings lexed from the shell string s."""
     shl = shlex(s, posix=True)
     shl.commenters = ""
     shl.whitespace = ""
@@ -98,7 +96,7 @@ def follow_sigil(shl, env, strict=False):
     param = next(shl)
     if param == "{":
         consume = list(takewhile(lambda t: t != "}", shl))
-        logger_debug('follow_sigil: consume:', consume)
+        logger_debug("follow_sigil: consume:", consume)
         consume = iter(consume)
         return follow_brace(consume, env, strict)
     return env.get(param, "")
@@ -157,7 +155,7 @@ def is_whitespace(s):
 
 def follow_brace(shl, env, strict=False):
     param = next(shl)
-    logger_debug('follow_brace: param:', repr(param))
+    logger_debug("follow_brace: param:", repr(param))
     if param == "#":
         word = next(shl)
 
@@ -178,12 +176,12 @@ def follow_brace(shl, env, strict=False):
         else:
             subst = ""
 
-    logger_debug('follow_brace: subst:', repr(subst))
+    logger_debug("follow_brace: subst:", repr(subst))
     param_unset = param not in env
     param_set_and_not_null = bool(subst and (param in env))
     try:
         modifier = next(shl)
-        logger_debug('follow_brace: modifier:', repr(modifier))
+        logger_debug("follow_brace: modifier:", repr(modifier))
         if is_whitespace(modifier):
             pass
         elif modifier == "%":
@@ -236,7 +234,7 @@ def follow_brace(shl, env, strict=False):
         elif modifier == "/":
             # this is a string replacement as in replace foo by bar using / as sep
             arg1 = next(shl)
-            logger_debug('follow_brace: subst/1: arg1.1:', repr(arg1))
+            logger_debug("follow_brace: subst/1: arg1.1:", repr(arg1))
             replace_all = False
             if arg1 == "/":
                 # with // replace all occurences
@@ -247,14 +245,15 @@ def follow_brace(shl, env, strict=False):
 
             # join anything in between the start / and middle /
             for na in shl:
-                logger_debug('follow_brace: subst/1: shl/na:', repr(na))
+                logger_debug("follow_brace: subst/1: shl/na:", repr(na))
                 if na == "/":
                     has_sep = True
                     break
                 arg1 += na
 
             logger_debug(
-                'follow_brace: subst/1: arg1.2:', repr(arg1), 'has_sep:', has_sep)
+                "follow_brace: subst/1: arg1.2:", repr(arg1), "has_sep:", has_sep
+            )
 
             arg2 = ""
             if has_sep:

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -288,7 +288,10 @@ def test_simple():
 
 def test_expand_simple():
     for string, (env, expected) in simple_simple_test_cases.items():
-        assert parameter_expansion.pe.expand_simple(string, env) == expected, (string, env)
+        assert parameter_expansion.pe.expand_simple(string, env) == expected, (
+            string,
+            env,
+        )
 
 
 def test_expand_strict_raises_Exception():
@@ -305,18 +308,38 @@ def test_tokenize_preserves_spaces():
     s = " - $parameter/$aa/${bb}   - \t- \n ${parameter/ aa /   - zz }- "
     tokens = list(parameter_expansion.pe.tokenize(s))
     expected = [
-        " ", "-", " ",
-        "$", "parameter",
+        " ",
+        "-",
+        " ",
+        "$",
+        "parameter",
         "/",
-        "$", "aa",
+        "$",
+        "aa",
         "/",
-        "$", "{", "bb", "}",
+        "$",
+        "{",
+        "bb",
+        "}",
         "   ",
         "-",
         " \t",
         "-",
         " \n ",
-        "$", "{", "parameter", "/", " ", "aa", " ", "/", "   ", "-", " ", "zz", " ", "}",
+        "$",
+        "{",
+        "parameter",
+        "/",
+        " ",
+        "aa",
+        " ",
+        "/",
+        "   ",
+        "-",
+        " ",
+        "zz",
+        " ",
+        "}",
         "-",
         " ",
     ]

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -5,11 +5,16 @@ import pytest
 import parameter_expansion as pex
 import parameter_expansion.pe
 
-Test = namedtuple("Test", ["tested_shell", "expected_str", "env"])
+#
+# This tuple describes a test case where we test the expansion of a
+# "tested_shell" strings with the "env" mapping of environment variables and
+# ensure that expanded results are equal to the "expected_str" string.
+Case = namedtuple("Case", ["tested_shell", "expected_str", "env"])
 
+#
+# tests POSIX expansion
 subst_test_cases = [
-    # string,        (set_and_not_null, set_but_null, unset)
-    Test(
+    Case(
         tested_shell="-$parameter-",
         expected_str="-set-",
         env={
@@ -17,7 +22,7 @@ subst_test_cases = [
             "word": "word",
         },  # set and not null
     ),
-    Test(
+    Case(
         tested_shell="-$parameter-",
         expected_str="--",
         env={
@@ -25,14 +30,14 @@ subst_test_cases = [
             "word": "word",
         },  # set but null
     ),
-    Test(
+    Case(
         tested_shell="-$parameter-",
         expected_str="-$parameter-",
         env={
             "word": "word",
         },  # unset
     ),
-    Test(
+    Case(
         tested_shell="-${parameter}-",
         expected_str="-set-",
         env={
@@ -40,7 +45,7 @@ subst_test_cases = [
             "word": "word",
         },  # set and not null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter}-",
         expected_str="--",
         env={
@@ -48,14 +53,14 @@ subst_test_cases = [
             "word": "word",
         },  # set but null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter}-",
         expected_str="--",
         env={
             "word": "word",
         },  # unset
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:-word}-",
         expected_str="-set-",
         env={
@@ -63,7 +68,7 @@ subst_test_cases = [
             "word": "word",
         },  # set and not null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:-word}-",
         expected_str="-word-",
         env={
@@ -71,14 +76,14 @@ subst_test_cases = [
             "word": "word",
         },  # set but null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:-word}-",
         expected_str="-word-",
         env={
             "word": "word",
         },  # unset
     ),
-    Test(
+    Case(
         tested_shell="-${parameter-word}-",
         expected_str="-set-",
         env={
@@ -86,7 +91,7 @@ subst_test_cases = [
             "word": "word",
         },  # set and not null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter-word}-",
         expected_str="--",
         env={
@@ -94,14 +99,14 @@ subst_test_cases = [
             "word": "word",
         },  # set but null
     ),
-    Test(
+    Case(
         tested_shell="-${parameter-word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:=word}-",
         env={
             "parameter": "set",
@@ -109,7 +114,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-set-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:=word}-",
         env={
             "parameter": "",
@@ -117,14 +122,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:=word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter=word}-",
         env={
             "parameter": "set",
@@ -132,7 +137,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-set-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter=word}-",
         env={
             "parameter": "",
@@ -140,14 +145,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="--",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter=word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:?word}-",
         env={
             "parameter": "set",
@@ -155,7 +160,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-set-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:?word}-",
         env={
             "parameter": "",
@@ -163,14 +168,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="error",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:?word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="error",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter?word}-",
         env={
             "parameter": "set",
@@ -178,7 +183,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-set-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter?word}-",
         env={
             "parameter": "",
@@ -186,14 +191,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="--",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter?word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="error",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:+word}-",
         env={
             "parameter": "set",
@@ -201,7 +206,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:+word}-",
         env={
             "parameter": "",
@@ -209,14 +214,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="--",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:+word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="--",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter:+word} -",
         env={
             "parameter": "set",
@@ -224,7 +229,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="- word -",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter:+word} -",
         env={
             "parameter": "",
@@ -232,14 +237,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="-  -",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter:+word} -",
         env={
             "word": "word",
         },  # unset
         expected_str="-  -",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter+word}-",
         env={
             "parameter": "set",
@@ -247,7 +252,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter+word}-",
         env={
             "parameter": "",
@@ -255,14 +260,14 @@ subst_test_cases = [
         },  # set but null
         expected_str="-word-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter+word}-",
         env={
             "word": "word",
         },  # unset
         expected_str="--",
     ),
-    Test(
+    Case(
         tested_shell="-${#parameter}-",
         env={
             "parameter": "set",
@@ -270,7 +275,7 @@ subst_test_cases = [
         },  # set and not null
         expected_str="-3-",
     ),
-    Test(
+    Case(
         tested_shell="-${#parameter}-",
         env={
             "parameter": "",
@@ -278,7 +283,7 @@ subst_test_cases = [
         },  # set but null
         expected_str="-0-",
     ),
-    Test(
+    Case(
         tested_shell="-${#parameter}-",
         env={
             "word": "word",
@@ -289,114 +294,114 @@ subst_test_cases = [
 
 affix_test_cases = [
     # tested shell string, (parameter, expected result)
-    Test(
+    Case(
         tested_shell="-${parameter%/*}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-aa/bb-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter%%/*}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-aa-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter#*/}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter##*/}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-cc-",
     ),
 ]
 
+# test Bash substrings
 substring_test_cases = [
-    # tested shell string, (parameter, expected result)
-    Test(
+    Case(
         tested_shell="-${parameter:0:2}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-aa-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:3:2}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-bb-",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter:3:2} -",
         env={"parameter": "aa/bb/cc"},
         expected_str="- bb -",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter:6}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-cc-",
     ),
 ]
 
+# test Bash string replacement
 replace_test_cases = [
-    # tested shell string,  (parameter, expected_str)
-    Test(
+    Case(
         tested_shell="-${parameter/aa/bb}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-bb/bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/aa}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-/bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/ aa / - zz }-",
         env={"parameter": "bb/ aa /cc"},
         expected_str="-bb/ - zz /cc-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/aa/}-",
         env={"parameter": "aa/bb/cc"},
         expected_str="-/bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/aa/zz}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="-zz/bb/aa-",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter/aa/zz} -",
         env={"parameter": "aa/bb/aa"},
         expected_str="- zz/bb/aa -",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter//aa/zz}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="-zz/bb/zz-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter//aa}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="-/bb/-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter//aa/ zz}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="- zz/bb/ zz-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/aa}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="-/bb/aa-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter//aa}-",
         env={"parameter": "aa/bb/aa"},
         expected_str="-/bb/-",
     ),
 ]
 
+# test expansion of nested plain parameters without expressions
 simple_test_cases = [
-    # tested shell string,    (env, expected result)
-    Test(
+    Case(
         tested_shell="-${parameter/$aa/$bb}-",
         env=dict(
             parameter="FOO/bb/cc",
@@ -405,7 +410,7 @@ simple_test_cases = [
         ),
         expected_str="-BAR/bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="- ${parameter/$aa/$bb} -",
         env=dict(
             parameter="FOO/bb/cc",
@@ -414,7 +419,7 @@ simple_test_cases = [
         ),
         expected_str="- BAR/bb/cc -",
     ),
-    Test(
+    Case(
         tested_shell="-$parameter/$aa/$bb-",
         env=dict(
             parameter="aa/bb/cc",
@@ -423,7 +428,7 @@ simple_test_cases = [
         ),
         expected_str="-aa/bb/cc/FOO/BAR-",
     ),
-    Test(
+    Case(
         tested_shell="-${parameter/${aa}/${bb}}-",
         env=dict(
             parameter="FOO/bb/cc",
@@ -432,7 +437,7 @@ simple_test_cases = [
         ),
         expected_str="-BAR/bb/cc-",
     ),
-    Test(
+    Case(
         tested_shell="-$parameter/$aa/${bb}-",
         expected_str="-aa/bb/cc/FOO/BAR-",
         env=dict(
@@ -441,7 +446,7 @@ simple_test_cases = [
             bb="BAR",
         ),
     ),
-    Test(
+    Case(
         tested_shell="- $parameter/$aa/${bb} -",
         env=dict(
             parameter="aa/bb/cc",
@@ -452,9 +457,9 @@ simple_test_cases = [
     ),
 ]
 
+# test expansion of plain parameters without expressions
 simple_simple_test_cases = [
-    # string,               env, result
-    Test(
+    Case(
         tested_shell="-$parameter/$aa/$bb-",
         env=dict(
             parameter="aa/bb/cc",
@@ -463,7 +468,7 @@ simple_simple_test_cases = [
         ),
         expected_str="-aa/bb/cc/FOO/BAR-",
     ),
-    Test(
+    Case(
         tested_shell="-$parameter/$aa/${bb}-",
         env=dict(
             parameter="aa/bb/cc",
@@ -472,7 +477,7 @@ simple_simple_test_cases = [
         ),
         expected_str="-aa/bb/cc/FOO/BAR-",
     ),
-    Test(
+    Case(
         tested_shell="- $parameter/$aa/${bb} -",
         expected_str="- aa/bb/cc/FOO/BAR -",
         env=dict(

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -561,6 +561,13 @@ def test_expand_can_handle_nested_substitution_and_pattern_expand():
     assert expanded_var == "alpha19"
 
 
+def test_expand_simple_expands_longest_param_name_first():
+    env = dict(pkg="foo", pkgver="bar")
+    var = "$pkgver"
+    expanded_var = pex.expand(var, env=env, strict=True)
+    assert expanded_var == "bar"
+
+
 def test_tokenize_preserves_spaces():
     s = " - $parameter/$aa/${bb}   - \t- \n ${parameter/ aa /   - zz }- "
     tokens = list(parameter_expansion.pe.tokenize(s))

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -293,7 +293,6 @@ subst_test_cases = [
 ]
 
 affix_test_cases = [
-    # tested shell string, (parameter, expected result)
     Case(
         tested_shell="-${parameter%/*}-",
         env={"parameter": "aa/bb/cc"},

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -1,297 +1,521 @@
+from collections import namedtuple
+
+import pytest
+
 import parameter_expansion as pex
 import parameter_expansion.pe
 
-subst_test_cases = {
-    # string,        set_and_not_null, set_but_null, unset
-    "-$parameter-": (
-        "-set-",
-        "--",
-        "--",
-    ),
-    "-${parameter}-": (
-        "-set-",
-        "--",
-        "--",
-    ),
-    "-${parameter:-word}-": (
-        "-set-",
-        "-word-",
-        "-word-",
-    ),
-    "-${parameter-word}-": (
-        "-set-",
-        "--",
-        "-word-",
-    ),
-    "-${parameter:=word}-": (
-        "-set-",
-        "-word-",
-        "-word-",
-    ),
-    "-${parameter=word}-": (
-        "-set-",
-        "--",
-        "-word-",
-    ),
-    "-${parameter:?word}-": (
-        "-set-",
-        "error",
-        "error",
-    ),
-    "-${parameter?word}-": (
-        "-set-",
-        "--",
-        "error",
-    ),
-    "-${parameter:+word}-": (
-        "-word-",
-        "--",
-        "--",
-    ),
-    "- ${parameter:+word} -": (
-        "- word -",
-        "-  -",
-        "-  -",
-    ),
-    "-${parameter+word}-": (
-        "-word-",
-        "-word-",
-        "--",
-    ),
-    "-${#parameter}-": (
-        "-3-",
-        "-0-",
-        "-0-",
-    ),
-}
+Test = namedtuple("Test", ["tested_shell", "expected_str", "env"])
 
-affix_test_cases = {
-    # string,               parameter, result
-    "-${parameter%/*}-": (
-        "aa/bb/cc",
-        "-aa/bb-",
+subst_test_cases = [
+    # string,        (set_and_not_null, set_but_null, unset)
+    Test(
+        tested_shell="-$parameter-",
+        expected_str="-set-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
     ),
-    "-${parameter%%/*}-": (
-        "aa/bb/cc",
-        "-aa-",
+    Test(
+        tested_shell="-$parameter-",
+        expected_str="--",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
     ),
-    "-${parameter#*/}-": (
-        "aa/bb/cc",
-        "-bb/cc-",
+    Test(
+        tested_shell="-$parameter-",
+        expected_str="-$parameter-",
+        env={
+            "word": "word",
+        },  # unset
     ),
-    "-${parameter##*/}-": (
-        "aa/bb/cc",
-        "-cc-",
+    Test(
+        tested_shell="-${parameter}-",
+        expected_str="-set-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
     ),
-}
+    Test(
+        tested_shell="-${parameter}-",
+        expected_str="--",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+    ),
+    Test(
+        tested_shell="-${parameter}-",
+        expected_str="--",
+        env={
+            "word": "word",
+        },  # unset
+    ),
+    Test(
+        tested_shell="-${parameter:-word}-",
+        expected_str="-set-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+    ),
+    Test(
+        tested_shell="-${parameter:-word}-",
+        expected_str="-word-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+    ),
+    Test(
+        tested_shell="-${parameter:-word}-",
+        expected_str="-word-",
+        env={
+            "word": "word",
+        },  # unset
+    ),
+    Test(
+        tested_shell="-${parameter-word}-",
+        expected_str="-set-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+    ),
+    Test(
+        tested_shell="-${parameter-word}-",
+        expected_str="--",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+    ),
+    Test(
+        tested_shell="-${parameter-word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter:=word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-set-",
+    ),
+    Test(
+        tested_shell="-${parameter:=word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter:=word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter=word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-set-",
+    ),
+    Test(
+        tested_shell="-${parameter=word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="--",
+    ),
+    Test(
+        tested_shell="-${parameter=word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter:?word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-set-",
+    ),
+    Test(
+        tested_shell="-${parameter:?word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="error",
+    ),
+    Test(
+        tested_shell="-${parameter:?word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="error",
+    ),
+    Test(
+        tested_shell="-${parameter?word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-set-",
+    ),
+    Test(
+        tested_shell="-${parameter?word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="--",
+    ),
+    Test(
+        tested_shell="-${parameter?word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="error",
+    ),
+    Test(
+        tested_shell="-${parameter:+word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter:+word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="--",
+    ),
+    Test(
+        tested_shell="-${parameter:+word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="--",
+    ),
+    Test(
+        tested_shell="- ${parameter:+word} -",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="- word -",
+    ),
+    Test(
+        tested_shell="- ${parameter:+word} -",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="-  -",
+    ),
+    Test(
+        tested_shell="- ${parameter:+word} -",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="-  -",
+    ),
+    Test(
+        tested_shell="-${parameter+word}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter+word}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="-word-",
+    ),
+    Test(
+        tested_shell="-${parameter+word}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="--",
+    ),
+    Test(
+        tested_shell="-${#parameter}-",
+        env={
+            "parameter": "set",
+            "word": "word",
+        },  # set and not null
+        expected_str="-3-",
+    ),
+    Test(
+        tested_shell="-${#parameter}-",
+        env={
+            "parameter": "",
+            "word": "word",
+        },  # set but null
+        expected_str="-0-",
+    ),
+    Test(
+        tested_shell="-${#parameter}-",
+        env={
+            "word": "word",
+        },  # unset
+        expected_str="-0-",
+    ),
+]
 
-substring_test_cases = {
-    # string,               parameter, result
-    "-${parameter:0:2}-": (
-        "aa/bb/cc",
-        "-aa-",
+affix_test_cases = [
+    # tested shell string, (parameter, expected result)
+    Test(
+        tested_shell="-${parameter%/*}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-aa/bb-",
     ),
-    "-${parameter:3:2}-": (
-        "aa/bb/cc",
-        "-bb-",
+    Test(
+        tested_shell="-${parameter%%/*}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-aa-",
     ),
-    "- ${parameter:3:2} -": (
-        "aa/bb/cc",
-        "- bb -",
+    Test(
+        tested_shell="-${parameter#*/}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-bb/cc-",
     ),
-    "-${parameter:6}-": (
-        "aa/bb/cc",
-        "-cc-",
+    Test(
+        tested_shell="-${parameter##*/}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-cc-",
     ),
-}
+]
 
-replace_test_cases = {
-    # string,               parameter, result
-    "-${parameter/aa/bb}-": (
-        "aa/bb/cc",
-        "-bb/bb/cc-",
+substring_test_cases = [
+    # tested shell string, (parameter, expected result)
+    Test(
+        tested_shell="-${parameter:0:2}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-aa-",
     ),
-    "-${parameter/aa}-": (
-        "aa/bb/cc",
-        "-/bb/cc-",
+    Test(
+        tested_shell="-${parameter:3:2}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-bb-",
     ),
-    "-${parameter/ aa / - zz }-": (
-        "bb/ aa /cc",
-        "-bb/ - zz /cc-",
+    Test(
+        tested_shell="- ${parameter:3:2} -",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="- bb -",
     ),
-    "-${parameter/aa/}-": (
-        "aa/bb/cc",
-        "-/bb/cc-",
+    Test(
+        tested_shell="-${parameter:6}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-cc-",
     ),
-    "-${parameter/aa/zz}-": (
-        "aa/bb/aa",
-        "-zz/bb/aa-",
-    ),
-    "- ${parameter/aa/zz} -": (
-        "aa/bb/aa",
-        "- zz/bb/aa -",
-    ),
-    "-${parameter//aa/zz}-": (
-        "aa/bb/aa",
-        "-zz/bb/zz-",
-    ),
-    "-${parameter//aa}-": (
-        "aa/bb/aa",
-        "-/bb/-",
-    ),
-    "-${parameter//aa/ zz}-": (
-        "aa/bb/aa",
-        "- zz/bb/ zz-",
-    ),
-    "-${parameter/aa}-": (
-        "aa/bb/aa",
-        "-/bb/aa-",
-    ),
-    "-${parameter//aa}-": (
-        "aa/bb/aa",
-        "-/bb/-",
-    ),
-}
+]
 
-simple_test_cases = {
+replace_test_cases = [
+    # tested shell string,  (parameter, expected_str)
+    Test(
+        tested_shell="-${parameter/aa/bb}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-bb/bb/cc-",
+    ),
+    Test(
+        tested_shell="-${parameter/aa}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-/bb/cc-",
+    ),
+    Test(
+        tested_shell="-${parameter/ aa / - zz }-",
+        env={"parameter": "bb/ aa /cc"},
+        expected_str="-bb/ - zz /cc-",
+    ),
+    Test(
+        tested_shell="-${parameter/aa/}-",
+        env={"parameter": "aa/bb/cc"},
+        expected_str="-/bb/cc-",
+    ),
+    Test(
+        tested_shell="-${parameter/aa/zz}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="-zz/bb/aa-",
+    ),
+    Test(
+        tested_shell="- ${parameter/aa/zz} -",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="- zz/bb/aa -",
+    ),
+    Test(
+        tested_shell="-${parameter//aa/zz}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="-zz/bb/zz-",
+    ),
+    Test(
+        tested_shell="-${parameter//aa}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="-/bb/-",
+    ),
+    Test(
+        tested_shell="-${parameter//aa/ zz}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="- zz/bb/ zz-",
+    ),
+    Test(
+        tested_shell="-${parameter/aa}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="-/bb/aa-",
+    ),
+    Test(
+        tested_shell="-${parameter//aa}-",
+        env={"parameter": "aa/bb/aa"},
+        expected_str="-/bb/-",
+    ),
+]
+
+simple_test_cases = [
+    # tested shell string,    (env, expected result)
+    Test(
+        tested_shell="-${parameter/$aa/$bb}-",
+        env=dict(
+            parameter="FOO/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+        expected_str="-BAR/bb/cc-",
+    ),
+    Test(
+        tested_shell="- ${parameter/$aa/$bb} -",
+        env=dict(
+            parameter="FOO/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+        expected_str="- BAR/bb/cc -",
+    ),
+    Test(
+        tested_shell="-$parameter/$aa/$bb-",
+        env=dict(
+            parameter="aa/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+        expected_str="-aa/bb/cc/FOO/BAR-",
+    ),
+    Test(
+        tested_shell="-${parameter/${aa}/${bb}}-",
+        env=dict(
+            parameter="FOO/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+        expected_str="-BAR/bb/cc-",
+    ),
+    Test(
+        tested_shell="-$parameter/$aa/${bb}-",
+        expected_str="-aa/bb/cc/FOO/BAR-",
+        env=dict(
+            parameter="aa/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+    ),
+    Test(
+        tested_shell="- $parameter/$aa/${bb} -",
+        env=dict(
+            parameter="aa/bb/cc",
+            aa="FOO",
+            bb="BAR",
+        ),
+        expected_str="- aa/bb/cc/FOO/BAR -",
+    ),
+]
+
+simple_simple_test_cases = [
     # string,               env, result
-    "-${parameter/$aa/$bb}-": (
-        dict(
-            parameter="FOO/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "-BAR/bb/cc-",
-    ),
-    "- ${parameter/$aa/$bb} -": (
-        dict(
-            parameter="FOO/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "- BAR/bb/cc -",
-    ),
-    "-$parameter/$aa/$bb-": (
-        dict(
+    Test(
+        tested_shell="-$parameter/$aa/$bb-",
+        env=dict(
             parameter="aa/bb/cc",
             aa="FOO",
             bb="BAR",
         ),
-        "-aa/bb/cc/FOO/BAR-",
+        expected_str="-aa/bb/cc/FOO/BAR-",
     ),
-    "-${parameter/${aa}/${bb}}-": (
-        dict(
-            parameter="FOO/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "-BAR/bb/cc-",
-    ),
-    "-$parameter/$aa/${bb}-": (
-        dict(
+    Test(
+        tested_shell="-$parameter/$aa/${bb}-",
+        env=dict(
             parameter="aa/bb/cc",
             aa="FOO",
             bb="BAR",
         ),
-        "-aa/bb/cc/FOO/BAR-",
+        expected_str="-aa/bb/cc/FOO/BAR-",
     ),
-    "- $parameter/$aa/${bb} -": (
-        dict(
+    Test(
+        tested_shell="- $parameter/$aa/${bb} -",
+        expected_str="- aa/bb/cc/FOO/BAR -",
+        env=dict(
             parameter="aa/bb/cc",
             aa="FOO",
             bb="BAR",
         ),
-        "- aa/bb/cc/FOO/BAR -",
     ),
-}
-
-simple_simple_test_cases = {
-    # string,               env, result
-    "-$parameter/$aa/$bb-": (
-        dict(
-            parameter="aa/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "-aa/bb/cc/FOO/BAR-",
-    ),
-    "-$parameter/$aa/${bb}-": (
-        dict(
-            parameter="aa/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "-aa/bb/cc/FOO/BAR-",
-    ),
-    "- $parameter/$aa/${bb} -": (
-        dict(
-            parameter="aa/bb/cc",
-            aa="FOO",
-            bb="BAR",
-        ),
-        "- aa/bb/cc/FOO/BAR -",
-    ),
-}
-
-test_envs = (
-    {
-        "parameter": "set",
-        "word": "word",
-    },  # set and not null
-    {
-        "parameter": "",
-        "word": "word",
-    },  # set but null
-    {
-        "word": "word",
-    },  # unset
-)
-
-test_case_map = (
-    "Set and not null",
-    "Set, but null",
-    "Unset",
-)
+]
 
 
-def test_expand():
-    for string, tc in subst_test_cases.items():
-        for i, env in enumerate(test_envs):
-            env = dict(env)  # Don't allow tests to mutate each other's envs
-            try:
-                result = string, pex.expand(string, env), tc[i], test_case_map[i]
-                assert result[1] == result[2], result
-            except pex.ParameterExpansionNullError:
-                assert tc[i] == "error", (string, tc[i], test_case_map[i])
-
-    for string, (parameter, expected) in affix_test_cases.items():
-        env = {"parameter": parameter}
-        assert pex.expand(string, env) == expected
+@pytest.mark.parametrize("test", subst_test_cases)
+def test_expand(test):
+    try:
+        result = pex.expand(test.tested_shell, env=test.env)
+        assert result == test.expected_str
+    except pex.ParameterExpansionNullError:
+        assert test.expected_str == "error"
 
 
-def test_substring():
-    for string, (parameter, expected) in substring_test_cases.items():
-        env = {"parameter": parameter}
-        assert pex.expand(string, env) == expected, (string, parameter)
+@pytest.mark.parametrize("test", affix_test_cases)
+def test_affix(test):
+    assert pex.expand(test.tested_shell, env=test.env) == test.expected_str
 
 
-def test_replace():
-    for string, (parameter, expected) in replace_test_cases.items():
-        env = {"parameter": parameter}
-        assert pex.expand(string, env) == expected, (string, parameter)
+@pytest.mark.parametrize("test", substring_test_cases)
+def test_substring(test):
+    assert pex.expand(test.tested_shell, env=test.env) == test.expected_str
 
 
-def test_simple():
-    for string, (env, expected) in simple_test_cases.items():
-        assert pex.expand(string, env) == expected, (string, env)
+@pytest.mark.parametrize("test", replace_test_cases)
+def test_replace(test):
+    assert pex.expand(test.tested_shell, env=test.env) == test.expected_str
 
 
-def test_expand_simple():
-    for string, (env, expected) in simple_simple_test_cases.items():
-        assert parameter_expansion.pe.expand_simple(string, env) == expected, (
-            string,
-            env,
-        )
+@pytest.mark.parametrize("test", simple_test_cases)
+def test_simple(test):
+    assert pex.expand(test.tested_shell, env=test.env) == test.expected_str
+
+
+@pytest.mark.parametrize("test", simple_simple_test_cases)
+def test_expand_simple(test):
+    assert pex.expand(test.tested_shell, env=test.env) == test.expected_str
 
 
 def test_expand_strict_raises_Exception():
@@ -302,6 +526,34 @@ def test_expand_strict_raises_Exception():
         raise Exception("ParameterExpansionNullError should be raised")
     except pex.ParameterExpansionNullError:
         pass
+
+
+def test_expand_can_handle_substring_with_no_start():
+    env = dict(_rpi_bt="1234567890ABCDEF")
+    var = "${_rpi_bt::8}"
+    expanded_var = pex.expand(var, env=env, strict=True)
+    assert expanded_var == "12345678"
+
+
+def test_expand_can_handle_substring_with_no_length():
+    env = dict(pyname="123456ABCD")
+    var = "${pyname:6}"
+    expanded_var = pex.expand(var, env=env, strict=True)
+    assert expanded_var == "ABCD"
+
+
+def test_expand_can_handle_nested_pound_expand():
+    env = dict(_pyname="cssselect2")
+    var = "${_pyname%${_pyname#?}}"
+    expanded_var = pex.expand(var, env=env, strict=True)
+    assert expanded_var == "c"
+
+
+def test_expand_can_handle_nested_substitution_and_pattern_expand():
+    env = dict(pkgver="0.8.0_alpha19")
+    var = "${pkgver/${pkgver%alpha*}/}"
+    expanded_var = pex.expand(var, env=env, strict=True)
+    assert expanded_var == "alpha19"
 
 
 def test_tokenize_preserves_spaces():

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -527,7 +527,7 @@ def test_expand_strict_raises_Exception():
     env = dict(foo="bar", bar="baz")
     try:
         pex.expand(string, env, strict=True)
-        raise Exception("ParameterExpansionNullError should be raised")
+        raise AssertionError("ParameterExpansionNullError should be raised")
     except pex.ParameterExpansionNullError:
         pass
 

--- a/parameter_expansion/tests/test_pe.py
+++ b/parameter_expansion/tests/test_pe.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-import pytest
+import pytest  # type: ignore
 
 import parameter_expansion as pex
 import parameter_expansion.pe


### PR DESCRIPTION
This PR contains a commit stream with several updates

- Ensure expansion does not strip spaces #17
- Fix issue in substring expansions
- Use namedtuples for parametrized pytest tests #14
- Enable nested parameter expansion #15
- Expand simple parameters from longest to shortest name #16
- Add new strict argument in `expand()` to raise exception if a parameter is missing from the environment
- Add optional debug logging/tracing
- Improve documentation

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>